### PR TITLE
fix(dlvp): skip validation for null and empty values

### DIFF
--- a/dlvp/src/main/java/io/github/linagora/linid/im/dlvp/DynamicListValidationPlugin.java
+++ b/dlvp/src/main/java/io/github/linagora/linid/im/dlvp/DynamicListValidationPlugin.java
@@ -98,16 +98,8 @@ public class DynamicListValidationPlugin implements ValidationPlugin, DynamicLis
   public Optional<I18nMessage> validate(
       final ValidationConfiguration configuration, final Object value) {
 
-    if (value == null) {
-      return Optional.of(
-          I18nMessage.of(
-              "error.plugin.dynamicListValidation.invalid.value",
-              Map.of(
-                  "allowedValues", List.of(),
-                  "value", "null"
-              )
-          )
-      );
+    if (value == null || value.toString().isEmpty()) {
+      return Optional.empty();
     }
 
     DynamicListConfiguration dlConfig = mapper.convertValue(

--- a/dlvp/src/test/java/io/github/linagora/linid/im/dlvp/DynamicListValidationPluginTest.java
+++ b/dlvp/src/test/java/io/github/linagora/linid/im/dlvp/DynamicListValidationPluginTest.java
@@ -113,19 +113,25 @@ class DynamicListValidationPluginTest {
   }
 
   @Test
-  @DisplayName("test validate: should return message on null value without making HTTP request")
+  @DisplayName("test validate: should accept null value without making HTTP request")
   void testValidateNullValue() {
     var configuration = buildConfiguration();
 
     var error = plugin.validate(configuration, null);
 
     assertNotNull(error);
-    assertTrue(error.isPresent());
-    assertEquals("error.plugin.dynamicListValidation.invalid.value", error.get().key());
-    assertEquals(
-        Map.of("allowedValues", List.of(), "value", "null"),
-        error.get().context()
-    );
+    assertTrue(error.isEmpty());
+  }
+
+  @Test
+  @DisplayName("test validate: should accept empty string value without making HTTP request")
+  void testValidateEmptyStringValue() {
+    var configuration = buildConfiguration();
+
+    var error = plugin.validate(configuration, "");
+
+    assertNotNull(error);
+    assertTrue(error.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
When an attribute with dynamic-list validation is not required, null or empty values should be accepted without calling the external API. Required validation is handled separately by rqvp.